### PR TITLE
Enable policy addons to install themselves

### DIFF
--- a/pkg/apis/agent/v1/types.go
+++ b/pkg/apis/agent/v1/types.go
@@ -47,30 +47,36 @@ const (
 )
 
 const (
-	WorkManagerAddonName = "work-manager"
-	ApplicationAddonName = "application-manager"
-	CertPolicyAddonName  = "cert-policy-controller"
-	IamPolicyAddonName   = "iam-policy-controller"
-	PolicyAddonName      = "policy-controller"
-	SearchAddonName      = "search-collector"
+	WorkManagerAddonName     = "work-manager"
+	ApplicationAddonName     = "application-manager"
+	CertPolicyAddonName      = "cert-policy-controller"
+	ConfigPolicyAddonName    = "config-policy-controller"
+	IamPolicyAddonName       = "iam-policy-controller"
+	PolicyAddonName          = "policy-controller"
+	PolicyFrameworkAddonName = "governance-policy-framework"
+	SearchAddonName          = "search-collector"
 )
 
 // KlusterletAddons is for klusterletAddon refactor, set true if the addon is ready to install by itself.
 var KlusterletAddons = map[string]bool{
-	WorkManagerAddonName: true,
-	ApplicationAddonName: false,
-	CertPolicyAddonName:  false,
-	IamPolicyAddonName:   false,
-	PolicyAddonName:      false,
-	SearchAddonName:      false,
+	WorkManagerAddonName:     true,
+	ApplicationAddonName:     false,
+	ConfigPolicyAddonName:    true,
+	CertPolicyAddonName:      true,
+	IamPolicyAddonName:       true,
+	PolicyAddonName:          true,
+	PolicyFrameworkAddonName: true,
+	SearchAddonName:          false,
 }
 
 // KlusterletAddonImageNames is the image key names for each addon agents in image-manifest configmap
 var KlusterletAddonImageNames = map[string][]string{
-	WorkManagerAddonName: []string{"multicloud_manager"},
-	ApplicationAddonName: []string{"multicluster_operators_subscription"},
-	CertPolicyAddonName:  []string{"cert_policy_controller"},
-	IamPolicyAddonName:   []string{"iam_policy_controller"},
-	PolicyAddonName:      []string{"config_policy_controller", "governance_policy_spec_sync", "governance_policy_status_sync", "governance_policy_template_sync"},
-	SearchAddonName:      []string{"search_collector"},
+	WorkManagerAddonName:     []string{"multicloud_manager"},
+	ApplicationAddonName:     []string{"multicluster_operators_subscription"},
+	ConfigPolicyAddonName:    []string{"config_policy_controller"},
+	CertPolicyAddonName:      []string{"cert_policy_controller"},
+	IamPolicyAddonName:       []string{"iam_policy_controller"},
+	PolicyAddonName:          []string{"config_policy_controller", "governance_policy_spec_sync", "governance_policy_status_sync", "governance_policy_template_sync"},
+	PolicyFrameworkAddonName: []string{"governance_policy_spec_sync", "governance_policy_status_sync", "governance_policy_template_sync"},
+	SearchAddonName:          []string{"search_collector"},
 }

--- a/pkg/apis/agent/v1/types.go
+++ b/pkg/apis/agent/v1/types.go
@@ -71,12 +71,14 @@ var KlusterletAddons = map[string]bool{
 
 // KlusterletAddonImageNames is the image key names for each addon agents in image-manifest configmap
 var KlusterletAddonImageNames = map[string][]string{
-	WorkManagerAddonName:     []string{"multicloud_manager"},
-	ApplicationAddonName:     []string{"multicluster_operators_subscription"},
-	ConfigPolicyAddonName:    []string{"config_policy_controller"},
-	CertPolicyAddonName:      []string{"cert_policy_controller"},
-	IamPolicyAddonName:       []string{"iam_policy_controller"},
-	PolicyAddonName:          []string{"config_policy_controller", "governance_policy_spec_sync", "governance_policy_status_sync", "governance_policy_template_sync"},
-	PolicyFrameworkAddonName: []string{"governance_policy_spec_sync", "governance_policy_status_sync", "governance_policy_template_sync"},
-	SearchAddonName:          []string{"search_collector"},
+	WorkManagerAddonName:  []string{"multicloud_manager"},
+	ApplicationAddonName:  []string{"multicluster_operators_subscription"},
+	ConfigPolicyAddonName: []string{"config_policy_controller"},
+	CertPolicyAddonName:   []string{"cert_policy_controller"},
+	IamPolicyAddonName:    []string{"iam_policy_controller"},
+	PolicyAddonName: []string{"config_policy_controller", "governance_policy_spec_sync",
+		"governance_policy_status_sync", "governance_policy_template_sync"},
+	PolicyFrameworkAddonName: []string{"governance_policy_spec_sync", "governance_policy_status_sync",
+		"governance_policy_template_sync"},
+	SearchAddonName: []string{"search_collector"},
 }

--- a/pkg/controller/addon/klusterlet_addon_controller.go
+++ b/pkg/controller/addon/klusterlet_addon_controller.go
@@ -525,11 +525,15 @@ func addonIsEnabled(addonName string, config *agentv1.KlusterletAddonConfig) boo
 	switch addonName {
 	case agentv1.ApplicationAddonName:
 		return config.Spec.ApplicationManagerConfig.Enabled
+	case agentv1.ConfigPolicyAddonName:
+		return config.Spec.PolicyController.Enabled
 	case agentv1.CertPolicyAddonName:
 		return config.Spec.CertPolicyControllerConfig.Enabled
 	case agentv1.IamPolicyAddonName:
 		return config.Spec.IAMPolicyControllerConfig.Enabled
 	case agentv1.PolicyAddonName:
+		return false // delete old ManagedClusterAddon
+	case agentv1.PolicyFrameworkAddonName:
 		return config.Spec.PolicyController.Enabled
 	case agentv1.SearchAddonName:
 		return config.Spec.SearchCollectorConfig.Enabled

--- a/pkg/controller/clustermanagementaddon/cluster_management_addon_controller.go
+++ b/pkg/controller/clustermanagementaddon/cluster_management_addon_controller.go
@@ -7,19 +7,16 @@ import (
 	"context"
 	"fmt"
 
-	agentv1 "github.com/stolostron/klusterlet-addon-controller/pkg/apis/agent/v1"
+	"github.com/stolostron/klusterlet-addon-controller/pkg/utils"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/klog/v2"
 	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
@@ -47,39 +44,12 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 
 	// Watch for changes to primary resource ClusterManagementAddon
 	err = c.Watch(&source.Kind{Type: &addonv1alpha1.ClusterManagementAddOn{}}, &handler.EnqueueRequestForObject{},
-		klusterletAddonPredicate())
+		utils.KlusterletAddonPredicate())
 	if err != nil {
 		return err
 	}
 
 	return nil
-}
-func klusterletAddonPredicate() predicate.Predicate {
-	return predicate.Predicate(predicate.Funcs{
-		GenericFunc: func(e event.GenericEvent) bool { return false },
-		CreateFunc: func(e event.CreateEvent) bool {
-			if e.Object == nil {
-				klog.Error(nil, "Create event has no runtime object to create", "event", e)
-				return false
-			}
-			return agentv1.KlusterletAddons[e.Meta.GetName()]
-		},
-		DeleteFunc: func(e event.DeleteEvent) bool {
-			if e.Object == nil {
-				klog.Error(nil, "Delete event has no runtime object to delete", "event", e)
-				return false
-			}
-			return agentv1.KlusterletAddons[e.Meta.GetName()]
-		},
-		UpdateFunc: func(e event.UpdateEvent) bool {
-			if e.MetaOld == nil || e.MetaNew == nil ||
-				e.ObjectOld == nil || e.ObjectNew == nil {
-				klog.Error(nil, "Update event is invalid", "event", e)
-				return false
-			}
-			return agentv1.KlusterletAddons[e.MetaNew.GetName()]
-		},
-	})
 }
 
 // blank assignment to verify that ReconcileClusterManagementAddOn implements reconcile.Reconciler

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -24,7 +24,9 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	manifestworkv1 "open-cluster-management.io/api/work/v1"
 )
@@ -276,4 +278,32 @@ func GetManifestWork(name, namespace string, client client.Client) (*manifestwor
 	}
 
 	return manifestWork, nil
+}
+
+func KlusterletAddonPredicate() predicate.Predicate {
+	return predicate.Predicate(predicate.Funcs{
+		GenericFunc: func(e event.GenericEvent) bool { return false },
+		CreateFunc: func(e event.CreateEvent) bool {
+			if e.Object == nil {
+				log.Error(nil, "Create event has no runtime object to create", "event", e)
+				return false
+			}
+			return agentv1.KlusterletAddons[e.Meta.GetName()]
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			if e.Object == nil {
+				log.Error(nil, "Delete event has no runtime object to delete", "event", e)
+				return false
+			}
+			return agentv1.KlusterletAddons[e.Meta.GetName()]
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			if e.MetaOld == nil || e.MetaNew == nil ||
+				e.ObjectOld == nil || e.ObjectNew == nil {
+				log.Error(nil, "Update event is invalid", "event", e)
+				return false
+			}
+			return agentv1.KlusterletAddons[e.MetaNew.GetName()]
+		},
+	})
 }

--- a/test/e2e/loopback_test.go
+++ b/test/e2e/loopback_test.go
@@ -82,7 +82,7 @@ var _ = Describe("Loopback test", func() {
 
 		By("Check addons are installed")
 		for addonName := range agentv1.KlusterletAddons {
-			if addonName == agentv1.WorkManagerAddonName {
+			if addonName == agentv1.WorkManagerAddonName || addonName == agentv1.PolicyAddonName {
 				continue
 			}
 			Eventually(func() error {
@@ -97,7 +97,7 @@ var _ = Describe("Loopback test", func() {
 
 		By("Check addons are deleted")
 		for addonName := range agentv1.KlusterletAddons {
-			if addonName == agentv1.WorkManagerAddonName {
+			if addonName == agentv1.WorkManagerAddonName || addonName == agentv1.PolicyAddonName {
 				continue
 			}
 			Eventually(func() error {
@@ -109,6 +109,5 @@ var _ = Describe("Loopback test", func() {
 				return fmt.Errorf("failed to get addon %v,%v", addonName, err)
 			}, 300*time.Second, 5*time.Second).ShouldNot(HaveOccurred())
 		}
-
 	})
 })


### PR DESCRIPTION
This enables the policy addons to be managed through their addon
controller. As part of this migration, the "policy-addon" has been split
into the config-policy-controller and the governance-policy-framework
addons.

Refs:
 - https://github.com/stolostron/backlog/issues/20012

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>