### PR TITLE
remove work-manager addon and fix values annotations update failure

### DIFF
--- a/pkg/apis/agent/v1/types.go
+++ b/pkg/apis/agent/v1/types.go
@@ -61,7 +61,6 @@ const (
 // true means it is deployed by addon-controller, can be updated and deleted.
 // false means it is not deployed by addon-controller, only can be updated, but cannot be deleted.
 var KlusterletAddons = map[string]bool{
-	WorkManagerAddonName:     false,
 	ApplicationAddonName:     true,
 	ConfigPolicyAddonName:    true,
 	CertPolicyAddonName:      true,
@@ -73,7 +72,6 @@ var KlusterletAddons = map[string]bool{
 
 // KlusterletAddonImageNames is the image key names for each addon agents in image-manifest configmap
 var KlusterletAddonImageNames = map[string][]string{
-	WorkManagerAddonName:  []string{"multicloud_manager"},
 	ApplicationAddonName:  []string{"multicluster_operators_subscription"},
 	ConfigPolicyAddonName: []string{"config_policy_controller"},
 	CertPolicyAddonName:   []string{"cert_policy_controller"},


### PR DESCRIPTION
1. remove watch work-manager . the ocm-controller can handle the image override and nodeselector.
2. fix the values annotation cannot be reconciled back  when the images changes.

Signed-off-by: Zhiwei Yin <zyin@redhat.com>