### PR TITLE
Add rbac proxy to config policy addon images

### DIFF
--- a/pkg/apis/agent/v1/types.go
+++ b/pkg/apis/agent/v1/types.go
@@ -73,7 +73,7 @@ var KlusterletAddons = map[string]bool{
 // KlusterletAddonImageNames is the image key names for each addon agents in image-manifest configmap
 var KlusterletAddonImageNames = map[string][]string{
 	ApplicationAddonName:  []string{"multicluster_operators_subscription"},
-	ConfigPolicyAddonName: []string{"config_policy_controller"},
+	ConfigPolicyAddonName: []string{"config_policy_controller", "kube_rbac_proxy"},
 	CertPolicyAddonName:   []string{"cert_policy_controller"},
 	IamPolicyAddonName:    []string{"iam_policy_controller"},
 	PolicyAddonName: []string{"config_policy_controller", "governance_policy_spec_sync",


### PR DESCRIPTION
Add rbac proxy to config policy addon images

The image is now used in the configuration-policy controller deployment,
to protect the metrics endpoint. Without this, it appears that clusters
which are disconnected from the usual image registries are not able to
pull the image. This should override the image on such clusters to the
locally-mirrored image.

Refs:
 - https://github.com/stolostron/backlog/issues/25250

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>