### PR TITLE
Fix the image name for the governance-policy-framework addon

### DIFF
--- a/pkg/apis/agent/v1/types.go
+++ b/pkg/apis/agent/v1/types.go
@@ -72,13 +72,11 @@ var KlusterletAddons = map[string]bool{
 
 // KlusterletAddonImageNames is the image key names for each addon agents in image-manifest configmap
 var KlusterletAddonImageNames = map[string][]string{
-	ApplicationAddonName:  []string{"multicluster_operators_subscription"},
-	ConfigPolicyAddonName: []string{"config_policy_controller", "kube_rbac_proxy"},
-	CertPolicyAddonName:   []string{"cert_policy_controller"},
-	IamPolicyAddonName:    []string{"iam_policy_controller"},
-	PolicyAddonName: []string{"config_policy_controller", "governance_policy_spec_sync",
-		"governance_policy_status_sync", "governance_policy_template_sync"},
-	PolicyFrameworkAddonName: []string{"governance_policy_spec_sync", "governance_policy_status_sync",
-		"governance_policy_template_sync"},
-	SearchAddonName: []string{"search_collector"},
+	ApplicationAddonName:     []string{"multicluster_operators_subscription"},
+	ConfigPolicyAddonName:    []string{"config_policy_controller", "kube_rbac_proxy"},
+	CertPolicyAddonName:      []string{"cert_policy_controller"},
+	IamPolicyAddonName:       []string{"iam_policy_controller"},
+	PolicyAddonName:          []string{"config_policy_controller", "governance_policy_framework_addon"},
+	PolicyFrameworkAddonName: []string{"governance_policy_framework_addon"},
+	SearchAddonName:          []string{"search_collector"},
 }


### PR DESCRIPTION
The governance-policy-framework addon was consolidated from three containers to a single container in ACM 2.7. This fixes the image references to use the single container image instead

Relates:
https://issues.redhat.com/browse/ACM-2523

Signed-off-by: mprahl <mprahl@users.noreply.github.com>