### PR TITLE
Add kube-rbac-proxy to addon image names

### DIFF
--- a/pkg/apis/agent/v1/types.go
+++ b/pkg/apis/agent/v1/types.go
@@ -77,6 +77,6 @@ var KlusterletAddonImageNames = map[string][]string{
 	CertPolicyAddonName:      []string{"cert_policy_controller"},
 	IamPolicyAddonName:       []string{"iam_policy_controller"},
 	PolicyAddonName:          []string{"config_policy_controller", "governance_policy_framework_addon"},
-	PolicyFrameworkAddonName: []string{"governance_policy_framework_addon"},
+	PolicyFrameworkAddonName: []string{"governance_policy_framework_addon", "kube_rbac_proxy"},
 	SearchAddonName:          []string{"search_collector"},
 }


### PR DESCRIPTION
Without it, disconnected environments were failing to pull the image from their registry.

ref: https://issues.redhat.com/browse/ACM-5326
