### PR TITLE
feat(tekton): enable multiarch build support (linux/x86_64, arm64, ppc64le, s390x)

### DIFF
--- a/.tekton/klusterlet-addon-controller-acm-214-pull-request.yaml
+++ b/.tekton/klusterlet-addon-controller-acm-214-pull-request.yaml
@@ -30,6 +30,9 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/arm64
+    - linux/ppc64le
+    - linux/s390x
   - name: dockerfile
     value: Dockerfile.rhtap
   - name: path-context
@@ -113,6 +116,9 @@ spec:
       type: string
     - default:
       - linux/x86_64
+      - linux/arm64
+      - linux/ppc64le
+      - linux/s390x
       description: List of platforms to build the container images on. The available
         set of values is determined by the configuration of the multi-platform-controller.
       name: build-platforms

--- a/.tekton/klusterlet-addon-controller-acm-214-push.yaml
+++ b/.tekton/klusterlet-addon-controller-acm-214-push.yaml
@@ -27,6 +27,9 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/arm64
+    - linux/ppc64le
+    - linux/s390x
   - name: dockerfile
     value: Dockerfile.rhtap
   - name: path-context
@@ -110,6 +113,9 @@ spec:
       type: string
     - default:
       - linux/x86_64
+      - linux/arm64
+      - linux/ppc64le
+      - linux/s390x
       description: List of platforms to build the container images on. The available
         set of values is determined by the configuration of the multi-platform-controller.
       name: build-platforms


### PR DESCRIPTION
Enable multiarch build support in Tekton pipeline files for linux/x86_64, linux/arm64, linux/ppc64le, and linux/s390x.